### PR TITLE
Revert "Add link to hooks library in README"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,2 @@
 # cds-hooks-library
-Library of community submitted hooks used as part of the CDS Hooks specification. 
-
-Hooks library: https://build.fhir.org/ig/HL7/cds-hooks-library
-
-Main specification: https://build.fhir.org/ig/HL7/cds-hooks
+Library of community submitted hooks used as part of the CDS Hooks specification. See https://build.fhir.org/ig/HL7/cds-hooks


### PR DESCRIPTION
Hey Guys, 

I think the idea here is that as part of preparing the IGs for snapshot/ballot/release publications, we'd manually edit the "cross-linking" to make it correct. 

I see this approach should be our plan B (or C) and instead work towards more automation. 

Isaac