### PR TITLE
address Grahame's feedback

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -6,16 +6,19 @@
 <br>
 This is the continuous integration, community release of the CDS Hooks specification. All stable releases are available at [https://cds-hooks.hl7.org](https://cds-hooks.hl7.org).
 </p>
-
 -->
+
 ## CDS Hooks Library
 
-The CDS Hooks Library contains specifications of industry standardized clinical workflow steps upon which remote clinical decision support can be requested. The names of the below hooks hyperlink to their specification and the number preceding their name indicates their maturity, according to the [CDS Hooks Maturity Model]({{site.data.fhir.cdshooks}}#hook-maturity-model). 
+### Introduction
+The CDS Hooks Library contains specifications of industry standardized clinical workflow steps upon which remote clinical decision support can be requested. The Library is an HL7 publication at the level of [Standard for Trial Use](https://hl7.org/fhir/versions.html#std-process). The names of the below hooks hyperlink to their individual specification and the number following their name indicates their specific maturity, according to the [CDS Hooks Maturity Model]({{site.data.fhir.cdshooks}}#hook-maturity-model). All hooks are intended to be used by systems conforming to the [HL7 CDS Hooks Implementation Guide]({{site.data.fhir.cdshooks}}). 
+
 New hooks are proposed in a [prescribed format]({{site.data.fhir.cdshooks}}#hook-definition-format) using the [documentation template](template.html) by submitting a pull request for community feedback. Hooks are versioned, and mature according to the Hook Maturity Model.
-Anyone may propose a new CDS Hooks hook.
+Anyone may propose a new CDS Hooks hook. News hooks will continue to be specified and matured in the Library while changes to the base CDS Hooks Implementation Guide become infrequent and tightly constrained.
 
-See https://cds-hooks.org/ for additional information, resources and ways to get involved.
+See [https://cds-hooks.org/](https://cds-hooks.org/) for additional information, resources and ways to get involved.
 
+### Hooks
 * [allergyintolerance-create](allergyintolerance-create.html) (1)
 * [appointment-book](appointment-book.html) (1)
 * [encounter-discharge](encounter-discharge.html) (1)

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -14,7 +14,7 @@ This is the continuous integration, community release of the CDS Hooks specifica
 The CDS Hooks Library contains specifications of industry standardized clinical workflow steps upon which remote clinical decision support can be requested. The Library is an HL7 publication at the level of [Standard for Trial Use](https://hl7.org/fhir/versions.html#std-process). The names of the below hooks hyperlink to their individual specification and the number following their name indicates their specific maturity, according to the [CDS Hooks Maturity Model]({{site.data.fhir.cdshooks}}#hook-maturity-model). All hooks are intended to be used by systems conforming to the [HL7 CDS Hooks Implementation Guide]({{site.data.fhir.cdshooks}}). 
 
 New hooks are proposed in a [prescribed format]({{site.data.fhir.cdshooks}}#hook-definition-format) using the [documentation template](template.html) by submitting a pull request for community feedback. Hooks are versioned, and mature according to the Hook Maturity Model.
-Anyone may propose a new CDS Hooks hook. News hooks will continue to be specified and matured in the Library while changes to the base CDS Hooks Implementation Guide become infrequent and tightly constrained.
+Anyone may propose a new CDS Hooks hook. New hooks will continue to be specified and matured in the Library while changes to the base CDS Hooks Implementation Guide become infrequent and tightly constrained.
 
 See [https://cds-hooks.org/](https://cds-hooks.org/) for additional information, resources and ways to get involved.
 

--- a/publication-request.json
+++ b/publication-request.json
@@ -9,7 +9,6 @@
     "first": true,
     "title": "CDS Hooks Hook Library",
     "ci-build": "http://build.fhir.org/ig/HL7/cds-hooks-library",
-    "canonical": "http://cds-hooks.hl7.org/hooks",
     "category": "Clinical Decision Support",
     "introduction": "The CDS Hooks Hook Library contains hook specifications exposed by CDS Hooks Clients to invoke CDS Hooks Services."
 }

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -25,9 +25,9 @@ publisher:
 # use cases, the value can be an object with keys for id, uri, and version.
 #
 dependencies:
-  hl7.fhir.uv.cds-hooks:
-    id: cdshooks
-    version: latest          # the Library should always reference the most recent published version of the base spec
+#  hl7.fhir.uv.cds-hooks:
+#    id: cdshooks
+#    version: latest          # the Library should always reference the most recent published version of the base spec
 #   hl7.fhir.us.core: 3.1.0
 #   hl7.fhir.us.mcode:
 #     id: mcode

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -27,7 +27,7 @@ publisher:
 dependencies:
   hl7.fhir.uv.cds-hooks:
     id: cdshooks
-    version: 2.0.1
+    version: latest          # the Library should always reference the most recent published version of the base spec
 #   hl7.fhir.us.core: 3.1.0
 #   hl7.fhir.us.mcode:
 #     id: mcode

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -27,7 +27,7 @@ publisher:
 dependencies:
   hl7.fhir.uv.cds-hooks:
     id: cdshooks
-    version: current
+    version: 2.0.1
 #   hl7.fhir.us.core: 3.1.0
 #   hl7.fhir.us.mcode:
 #     id: mcode


### PR DESCRIPTION
1. Dependency should be on `latest` CDS Hooks base IG, not `current` !
-- But, latest has never been published, sushi returning this error:
`Sushi: error Failed to load hl7.fhir.uv.cds-hooks#latest: Failed to resolve version for hl7.fhir.uv.cds-hooks#latest (00:00.701 / 00:11.919, 113Mb)`

2. Add more/better intro

