### PR TITLE
Merge right before next publication!

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -25,9 +25,9 @@ publisher:
 # use cases, the value can be an object with keys for id, uri, and version.
 #
 dependencies:
-#  hl7.fhir.uv.cds-hooks:
-#    id: cdshooks
-#    version: latest          # the Library should always reference the most recent published version of the base spec
+  hl7.fhir.uv.cds-hooks:
+    id: cdshooks
+    version: latest          # the Library should always reference the most recent published version of the base spec
 #   hl7.fhir.us.core: 3.1.0
 #   hl7.fhir.us.mcode:
 #     id: mcode


### PR DESCRIPTION
Because we're publishing both the CDS Hooks and CDS Hooks Library IGs for the first time, at the same time, we need to orchestrate the order of publication by following these steps:

## Sequence of events of publication process

1. Merge https://github.com/HL7/cds-hooks/pull/16
2. Publish CDS Hooks
3. Merge this PR (#17) ! (which updates the CDS Hooks Library to depend upon latest CDS Hooks publication).
4. Publish CDS Hooks Library