### PR TITLE
Fix page standards statuses to display correctly

### DIFF
--- a/FHIR-cds-hooks-library.xml
+++ b/FHIR-cds-hooks-library.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ciUrl="http://build.fhir.org/ig/HL7/cds-hooks-library" defaultVersion="1.0.1" defaultWorkgroup="cds" gitUrl="https://github.com/HL7/cds-hooks-library" url="http://cds-hooks.hl7.org/hooks">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="https://cds-hooks.hl7.org/ballots/2023Sep/" ciUrl="http://build.fhir.org/ig/HL7/cds-hooks-library" defaultVersion="1.0.1" defaultWorkgroup="cds" gitUrl="https://github.com/HL7/cds-hooks-library" url="http://cds-hooks.hl7.org/hooks">
 <version code="current" url="http://build.fhir.org/ig/HL7/cds-hooks-library"/>
 <version code="1.0.1" url="http://cds-hooks.hl7.org/hooks/STU1"/>
+<version code="1.0.1-ballot" url="https://cds-hooks.hl7.org/ballots/2023Sep/"/>
 <artifactPageExtension value="-definitions"/>
 <artifactPageExtension value="-examples"/>
 <artifactPageExtension value="-mappings"/>

--- a/input/pagecontent/appointment-book.md
+++ b/input/pagecontent/appointment-book.md
@@ -1,9 +1,5 @@
 ### `appointment-book`
 
-<blockquote >
-    This page defines a workflow <a href="{{site.data.related.cdshooks.link}}/index.html#hooks">hook</a> for the purpose of providing clinical decision support using CDS Hooks. This is a <b>release</b> at the level of <a href="http://hl7.org/fhir/versions.html#std-processs">Trial Use</a>.
-</blockquote>
-
 <blockquote style="background-color: rgba(255, 213, 128, 0.5);">
   <p>
     <b>Looking for Feedback:</b>

--- a/input/pagecontent/encounter-discharge.md
+++ b/input/pagecontent/encounter-discharge.md
@@ -1,9 +1,5 @@
 ### `encounter-discharge`
 
-<blockquote >
-    This page defines a workflow <a href="{{site.data.related.cdshooks.link}}/index.html#hooks">hook</a> for the purpose of providing clinical decision support using CDS Hooks. This is a <b>release</b> at the level of <a href="http://hl7.org/fhir/versions.html#std-processs">Trial Use</a>.
-</blockquote>
-
 | Metadata | Value |
 | ---- | ---- |
 | specificationVersion | 1.0 |

--- a/input/pagecontent/encounter-start.md
+++ b/input/pagecontent/encounter-start.md
@@ -1,9 +1,5 @@
 ### `encounter-start`
 
-<blockquote >
-    This page defines a workflow <a href="{{site.data.related.cdshooks.link}}/index.html#hooks">hook</a> for the purpose of providing clinical decision support using CDS Hooks. This is a <b>release</b> at the level of <a href="http://hl7.org/fhir/versions.html#std-processs">Trial Use</a>.
-</blockquote>
-
 <blockquote style="background-color: rgba(255, 213, 128, 0.5);">
     <b>Looking for Feedback:</b>
     Hey implementers, we want to hear from you!

--- a/input/pagecontent/medication-refill.md
+++ b/input/pagecontent/medication-refill.md
@@ -1,9 +1,5 @@
 ### `medication-refill`
 
-<blockquote >
-    This page defines a workflow <a href="{{site.data.related.cdshooks.link}}/index.html#hooks">hook</a> for the purpose of providing clinical decision support using CDS Hooks. This is a <b>snapshot</b> at the level of <a href="http://hl7.org/fhir/versions.html#std-processs">Draft</a>.
-</blockquote>
-
 | Metadata | Value |
 | ---- | ---- |
 | specificationVersion | 2.0 |

--- a/input/pagecontent/order-dispatch.md
+++ b/input/pagecontent/order-dispatch.md
@@ -1,9 +1,5 @@
 ### `order-dispatch`
 
-<blockquote >
-    This page defines a workflow <a href="{{site.data.related.cdshooks.link}}/index.html#hooks">hook</a> for the purpose of providing clinical decision support using CDS Hooks. This is a <b>release</b> at the level of <a href="http://hl7.org/fhir/versions.html#std-processs">Trial Use</a>.
-</blockquote>
-
 | Metadata | Value |
 | ---- | ---- |
 | specificationVersion | 2.0 |

--- a/input/pagecontent/order-select.md
+++ b/input/pagecontent/order-select.md
@@ -1,9 +1,5 @@
 ### `order-select`
 
-<blockquote >
-    This page defines a workflow <a href="{{site.data.related.cdshooks.link}}/index.html#hooks">hook</a> for the purpose of providing clinical decision support using CDS Hooks. This is a <b>release</b> at the level of <a href="http://hl7.org/fhir/versions.html#std-processs">Trial Use</a>.
-</blockquote>
-
 | Metadata | Value |
 | ---- | ---- |
 | specificationVersion | 1.0 |

--- a/input/pagecontent/order-sign.md
+++ b/input/pagecontent/order-sign.md
@@ -1,9 +1,5 @@
 ### `order-sign`
 
-<blockquote >
-    This page defines a workflow <a href="{{site.data.related.cdshooks.link}}/index.html#hooks">hook</a> for the purpose of providing clinical decision support using CDS Hooks. This is a <b>release</b> at the level of <a href="http://hl7.org/fhir/versions.html#std-processs">Trial Use</a>.
-</blockquote>
-
 | Metadata | Value |
 | ---- | ---- |
 | specificationVersion | 1.0 |

--- a/input/pagecontent/patient-view.md
+++ b/input/pagecontent/patient-view.md
@@ -1,9 +1,5 @@
 ### `patient-view`
 
-<blockquote >
-    This page defines a workflow <a href="{{site.data.related.cdshooks.link}}/index.html#hooks">hook</a> for the purpose of providing clinical decision support using CDS Hooks. This is a <b>release</b> at the level of <a href="http://hl7.org/fhir/versions.html#std-processs">Trial Use</a>.
-</blockquote>
-
 | Metadata | Value |
 | ---- | ---- |
 | specificationVersion | 1.0 |

--- a/input/pagecontent/problem-list-item-create.md
+++ b/input/pagecontent/problem-list-item-create.md
@@ -1,9 +1,5 @@
 ### `problem-list-item-create`
 
-<blockquote >
-    This page defines a workflow <a href="{{site.data.related.cdshooks.link}}/index.html#hooks">hook</a> for the purpose of providing clinical decision support using CDS Hooks. This is a <b>snapshot</b> at the level of <a href="http://hl7.org/fhir/versions.html#std-processs">Draft</a>.
-</blockquote>
-
 | Metadata | Value |
 | ---- | ---- |
 | specificationVersion | 1.0 |

--- a/input/pagecontent/template.md
+++ b/input/pagecontent/template.md
@@ -1,9 +1,5 @@
 # <mark>`hook-name-expressed-as-noun-verb`</mark>
 
-<blockquote>
-    This page defines a workflow <a href="https://build.fhir.org/ig/HL7/cds-hooks/#hooks"><b>hook</b></a> for the purpose of providing clinical decision support using CDS Hooks. This is a <mark><b>build</b> | <b>snapshot</b> | <b>ballot</b> | <b>release</b></mark> at the level of <mark><a href="http://hl7.org/fhir/versions.html#std-processs"><b>Draft | Trial Use | Normative | Informative | Deprecated</b></a></mark>
-</blockquote>
-
 | Metadata | Value |
 | ---- | ---- |
 | specificationVersion | 1.0 |

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -59,18 +59,57 @@ pages:
   index.md:
     title: Overview
   allergyintolerance-create.md:
+    extension:
+    - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
+      valueCode: trial-use
   appointment-book.md:
+    extension:
+    - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
+      valueCode: trial-use
   encounter-discharge.md:
+    extension:
+    - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
+      valueCode: trial-use
   encounter-start.md:
+    extension:
+    - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
+      valueCode: trial-use
   medication-prescribe.md:
+    extension:
+    - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
+      valueCode: trial-use
   medication-refill.md:
+    extension:
+    - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
+      valueCode: draft
   order-dispatch.md:
+    extension:
+    - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
+      valueCode: trial-use
   order-review.md:
+    extension:
+    - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
+      valueCode: trial-use
   order-select.md:
+    extension:
+    - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
+      valueCode: trial-use
   order-sign.md:
+    extension:
+    - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
+      valueCode: trial-use
   patient-view.md:
+    extension:
+    - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
+      valueCode: trial-use
   problem-list-item-create.md:
+    extension:
+    - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
+      valueCode: draft
   template.md:
+    extension:
+    - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
+      valueCode: trial-use
 #
 # The parameters property represents IG.definition.parameter. Rather
 # than a list of code/value pairs (as in the ImplementationGuide


### PR DESCRIPTION
Fix page standards statuses to display correctly, and remove duplicate text we were adding ourselves outside of the IG Publisher framework.

See https://chat.fhir.org/#narrow/channel/179252-IG-creation/topic/standard-status.20of.20informative.20appearing.20in.20IGs.3F/with/513905621 for background.